### PR TITLE
fix: handling error tree-sitter trees with unfinished dot completion

### DIFF
--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -77,6 +77,15 @@ func IsModuleScope(doc DocumentContent, node *sitter.Node) bool {
 	for n := node.Parent(); n != nil; n = n.Parent() {
 		if n.Type() == NodeTypeFunctionDef {
 			return false
+		} else if n.Type() == NodeTypeERROR && n.ChildCount() >= 2 {
+			// upon dot completion inside the function, if the current node is "." (dot), then tree-sitter will fail
+			// to parse valid syntax, therefore instead of functionDefinition node there will be ERROR node.
+			// Let's check its direct named kids. It should have identifier (errored function definition) and parameters
+			if child1, child2 := n.NamedChild(0), n.NamedChild(1); child1 != nil && child2 != nil {
+				if child1.Type() == NodeTypeIdentifier && child2.Type() == NodeTypeParameters {
+					return false
+				}
+			}
 		}
 	}
 	return true

--- a/pkg/query/symbol_test.go
+++ b/pkg/query/symbol_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/autokitteh/starlark-lsp/pkg/query"
 )
 
+func names(symbols []query.Symbol) []string {
+	names := make([]string, len(symbols))
+	for i, sym := range symbols {
+		names[i] = sym.Name
+	}
+	return names
+}
+
 func TestQueryDocumentSymbols(t *testing.T) {
 	f := newQueryFixture(t, "", `
 x = a(3)
@@ -18,11 +26,7 @@ z = True
 
 	doc := f.document()
 	symbols := query.DocumentSymbols(doc)
-	names := make([]string, len(symbols))
-	for i, sym := range symbols {
-		names[i] = sym.Name
-	}
-	assert.Equal(t, []string{"x", "y", "z"}, names)
+	assert.Equal(t, []string{"x", "y", "z"}, names(symbols))
 }
 
 func TestQuerySiblingSymbols(t *testing.T) {
@@ -42,11 +46,7 @@ def start():
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SiblingSymbols(doc, n.Parent().NamedChild(0), nil)
-	names := make([]string, len(symbols))
-	for i, sym := range symbols {
-		names[i] = sym.Name
-	}
-	assert.Equal(t, []string{"bar", "baz"}, names)
+	assert.Equal(t, []string{"bar", "baz"}, names(symbols))
 }
 
 func TestSymbolsInScope(t *testing.T) {
@@ -66,11 +66,7 @@ def start():
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SymbolsInScope(doc, n)
-	names := make([]string, len(symbols))
-	for i, sym := range symbols {
-		names[i] = sym.Name
-	}
-	assert.Equal(t, []string{"bar", "baz"}, names)
+	assert.Equal(t, []string{"bar", "baz"}, names(symbols))
 }
 
 func TestSymbolsInScopeExcludesFollowingSiblings(t *testing.T) {
@@ -91,11 +87,7 @@ def start():
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SymbolsInScope(doc, n)
-	names := make([]string, len(symbols))
-	for i, sym := range symbols {
-		names[i] = sym.Name
-	}
-	assert.Equal(t, []string{"bar", "baz"}, names)
+	assert.Equal(t, []string{"bar", "baz"}, names(symbols))
 }
 
 func TestSymbolsInScopeIncludesFunctionArguments1(t *testing.T) {
@@ -112,11 +104,7 @@ def foo(a, b=True, c=None):
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SymbolsInScope(doc, n)
-	names := make([]string, len(symbols))
-	for i, sym := range symbols {
-		names[i] = sym.Name
-	}
-	assert.Equal(t, []string{"bar", "baz", "a", "b", "c"}, names)
+	assert.Equal(t, []string{"bar", "baz", "a", "b", "c"}, names(symbols))
 }
 
 func TestSymbolsInScopeIncludesFunctionArguments2(t *testing.T) {
@@ -133,9 +121,79 @@ def foo(a, b=True, c=None):
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 4, Character: 4})
 	assert.True(t, ok)
 	symbols := query.SymbolsInScope(doc, n)
-	names := make([]string, len(symbols))
-	for i, sym := range symbols {
-		names[i] = sym.Name
-	}
-	assert.Equal(t, []string{"d", "bar", "baz", "a", "b", "c"}, names)
+	assert.Equal(t, []string{"d", "bar", "baz", "a", "b", "c"}, names(symbols))
+}
+
+func TestSymbolsInScopeDotCompletion1(t *testing.T) {
+	f := newQueryFixture(t, "", `
+def foo():
+  bar = 1
+  bar.
+  # position is dot
+`)
+	// module [0, 0] - [3, 0]
+	//  ERROR [0, 0] - [2, 6]
+	//    identifier [0, 4] - [0, 7]
+	//    parameters [0, 7] - [0, 9]
+	//    expression_statement [1, 2] - [1, 9]
+	//      assignment [1, 2] - [1, 9]
+	//        left: identifier [1, 2] - [1, 5]
+	//        right: integer [1, 8] - [1, 9]
+	//    identifier [2, 2] - [2, 5]
+
+	doc := f.document()
+	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 3, Character: 5}) // dot
+	assert.Equal(t, n.Type(), query.NodeTypeERROR)
+	assert.True(t, ok)
+	assert.True(t, query.IsModuleScope(doc, n)) // ERROR is below module (failed to parse function definition) therefore the scope is module
+
+	n, ok = query.NamedNodeAtPosition(doc, protocol.Position{Line: 3, Character: 4}) // bar
+	assert.True(t, ok)
+	symbols := query.SymbolsInScope(doc, n)
+	assert.False(t, query.IsModuleScope(doc, n)) // bar is below highest ERROR + identifier and parameters, assume this is ERROR function definition
+	assert.Equal(t, []string{"bar"}, names(symbols))
+}
+
+func TestSymbolsInScopeDotCompletion2(t *testing.T) {
+	f := newQueryFixture(t, "", `
+def foo():
+	bar = 1
+	bar.
+	
+def foo2():
+	pass
+`)
+	// after dot there is more chars, therefore tree sitter will try to parse it as a ERROR call expression
+
+	//module [0, 0] - [6, 0]
+	//  function_definition [0, 0] - [5, 6]
+	//    name: identifier [0, 4] - [0, 7]
+	//    parameters: parameters [0, 7] - [0, 9]
+	//    body: block [1, 2] - [5, 6]
+	//      expression_statement [1, 2] - [1, 9]
+	//        assignment [1, 2] - [1, 9]
+	//          left: identifier [1, 2] - [1, 5]
+	//          right: integer [1, 8] - [1, 9]
+	//      ERROR [2, 2] - [4, 9]
+	//        call [2, 2] - [4, 8]
+	//          function: attribute [2, 2] - [4, 3]         <- dot
+	//            object: identifier [2, 2] - [2, 5]        <- bar
+	//            attribute: identifier [4, 0] - [4, 3]
+	//          ERROR [4, 4] - [4, 6]
+	//            identifier [4, 4] - [4, 6]
+	//          arguments: argument_list [4, 6] - [4, 8]
+	//      pass_statement [5, 2] - [5, 6]
+	//
+
+	doc := f.document()
+	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 3, Character: 5}) // dot
+	assert.Equal(t, n.Type(), query.NodeTypeAttribute)
+	assert.True(t, ok)
+	assert.False(t, query.IsModuleScope(doc, n)) // this time there is function defintion on top level
+
+	n, ok = query.NamedNodeAtPosition(doc, protocol.Position{Line: 3, Character: 4}) // bar
+	assert.True(t, ok)
+	symbols := query.SymbolsInScope(doc, n)
+	assert.False(t, query.IsModuleScope(doc, n))
+	assert.Equal(t, []string{"bar"}, names(symbols))
 }


### PR DESCRIPTION
fix: local/module scope recognition on trees with error