### PR TITLE
feat: findObjExpression to match more cases

### DIFF
--- a/pkg/analysis/signature.go
+++ b/pkg/analysis/signature.go
@@ -64,7 +64,7 @@ func (a *Analyzer) checkForTypedMethod(doc document.Document, node *sitter.Node,
 	if query.PointAfterOrEqual(node.StartPoint(), afterDot) {
 		node = node.Parent()
 	}
-	expr := a.findAttrObjectExpression([]*sitter.Node{node}, afterDot)
+	expr := a.findObjectExpression([]*sitter.Node{node}, afterDot)
 	if t := a.analyzeType(doc, expr); t != "" {
 		if ty, ok := a.builtins.Types[t]; ok {
 			return ty.FindMethod(methodName)


### PR DESCRIPTION
handle more cases in findObjExpression

- rename findAttrObjExpression to findObjExpression
- handle two more cases in addition to `attribute` node case